### PR TITLE
Remove is_wild_fire()

### DIFF
--- a/fire/FatesRxFireMod.F90
+++ b/fire/FatesRxFireMod.F90
@@ -47,29 +47,4 @@ module FatesRxFireMod
   
   end logical function is_prescribed_burn
   
-  !---------------------------------------------------------------------------------------
-  
-  logical function fire_has_ignitions_and_intensity(wildfire_FI, wildfire_ignitions,         &
-    wildfire_FI_thresh)
-    !
-    !  DESCRIPTION:
-    !  Determines if a wildfire is happening
-    !
-    
-    ! ARGUMENTS:
-    real(r8), intent(in) :: wildfire_FI        ! wildfire fire intensity [kW/m]
-    real(r8), intent(in) :: wildfire_ignitions ! wildfire ignitions [count/km2/day]
-    real(r8), intent(in) :: wildfire_FI_thresh ! threshold for fires that spread or go out [kW/m]
-    
-    ! LOCALS:
-    logical :: has_ignitions         ! any natural ignitions at the site?
-    logical :: above_wildfire_thresh ! above the wildfire energy threshold
-    
-    has_ignitions = wildfire_ignitions > nearzero
-    above_wildfire_thresh = wildfire_FI > wildfire_FI_thresh
-  
-    is_wildfire = has_ignitions .and. above_wildfire_thresh
-  
-  end logical function fire_has_ignitions_and_intensity
-  
 end module FatesRxFireMod

--- a/fire/FatesRxFireMod.F90
+++ b/fire/FatesRxFireMod.F90
@@ -49,7 +49,7 @@ module FatesRxFireMod
   
   !---------------------------------------------------------------------------------------
   
-  logical function is_wild_fire(wildfire_FI, wildfire_ignitions, rxfire_maxFI,         &
+  logical function fire_has_ignitions_and_intensity(wildfire_FI, wildfire_ignitions, rxfire_maxFI,         &
     wildfire_intensity_thresh)
     !
     !  DESCRIPTION:
@@ -79,6 +79,6 @@ module FatesRxFireMod
       
     is_wildfire = managed_wildfire .or. true_wildfire
   
-  end logical function is_wild_fire
+  end logical function fire_has_ignitions_and_intensity
   
 end module FatesRxFireMod

--- a/fire/FatesRxFireMod.F90
+++ b/fire/FatesRxFireMod.F90
@@ -50,7 +50,7 @@ module FatesRxFireMod
   !---------------------------------------------------------------------------------------
   
   logical function fire_has_ignitions_and_intensity(wildfire_FI, wildfire_ignitions,         &
-    wildfire_intensity_thresh)
+    wildfire_FI_thresh)
     !
     !  DESCRIPTION:
     !  Determines if a wildfire is happening

--- a/fire/FatesRxFireMod.F90
+++ b/fire/FatesRxFireMod.F90
@@ -49,7 +49,7 @@ module FatesRxFireMod
   
   !---------------------------------------------------------------------------------------
   
-  logical function fire_has_ignitions_and_intensity(wildfire_FI, wildfire_ignitions, rxfire_maxFI,         &
+  logical function fire_has_ignitions_and_intensity(wildfire_FI, wildfire_ignitions,         &
     wildfire_intensity_thresh)
     !
     !  DESCRIPTION:
@@ -59,25 +59,16 @@ module FatesRxFireMod
     ! ARGUMENTS:
     real(r8), intent(in) :: wildfire_FI        ! wildfire fire intensity [kW/m]
     real(r8), intent(in) :: wildfire_ignitions ! wildfire ignitions [count/km2/day]
-    real(r8), intent(in) :: rx_max_FI          ! maximum fire energy of prescribed fire [kW/m]
     real(r8), intent(in) :: wildfire_FI_thresh ! threshold for fires that spread or go out [kW/m]
     
     ! LOCALS:
-    logical :: managed_wildfire      ! is it a wildfire with FI lower than the max rxfire intensity? [can either be Rx fire or wildfire]
-    logical :: true_wildfire         ! is it a wildfire that cannot be managed?
     logical :: has_ignitions         ! any natural ignitions at the site?
     logical :: above_wildfire_thresh ! above the wildfire energy threshold
     
     has_ignitions = wildfire_ignitions > nearzero
     above_wildfire_thresh = wildfire_FI > wildfire_FI_thresh
   
-    managed_wildfire = has_ignitions .and. above_wildfire_thresh .and.  &
-      wildfire_FI < rx_max_FI
-
-    true_wildfire = has_ignitions .and. above_wildfire_thresh .and.  &
-      wildfire_FI > rx_max_FI
-      
-    is_wildfire = managed_wildfire .or. true_wildfire
+    is_wildfire = has_ignitions .and. above_wildfire_thresh
   
   end logical function fire_has_ignitions_and_intensity
   

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -371,7 +371,7 @@ contains
     use SFParamsMod,       only : SF_val_rxfire_maxthreshold, SF_val_rxfire_fuel_min
     use SFParamsMod,       only : SF_val_rxfire_fuel_max
     use EDParamsMod,       only : rxfire_switch
-    use FatesRxFireMod,    only : is_prescribed_burn, is_wild_fire
+    use FatesRxFireMod,    only : is_prescribed_burn, fire_has_ignitions_and_intensity
 
     ! ARGUMENTS:
     type(ed_site_type), intent(inout), target :: currentSite
@@ -423,7 +423,7 @@ contains
             is_rxfire = is_prescribed_burn(currentPatch%FI, currentSite%NF, &
               SF_val_rxfire_minthreshold, SF_val_rxfire_maxthreshold, SF_val_fire_threshold)
 
-            is_wildfire = is_wild_fire(currentPatch%FI, currentSite%NF, SF_val_rxfire_minthreshold, &
+            is_wildfire = fire_has_ignitions_and_intensity(currentPatch%FI, currentSite%NF, SF_val_rxfire_minthreshold, &
               SF_val_fire_threshold)
 
             if (is_rxfire) then


### PR DESCRIPTION
Since the managed vs. not distinction isn't used, we can remove it, simplifying `is_wild_fire()`. That function thus becomes just checking whether (a) there are ignitions and (b) potential fire intensity is greater than the threshold. In the only place the function is used, it's already underneath a check that number of fires is > 0, so (a) isn't useful. Thus, we can replace all uses of the function with just a check of (b).